### PR TITLE
support rejected slot from $slots

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,9 @@ export const Promised = {
     }
 
     if (this.error) {
-      assert(this.$scopedSlots.rejected, 'No slot "rejected" provided. Cannot display the error')
-      const node = this.$scopedSlots.rejected(this.error)
+      const slot = this.$scopedSlots.rejected || this.$slots.rejected
+      assert(slot, 'No slot "rejected" provided. Cannot display the error')
+      const node = slot(this.error)
       assert(
         (Array.isArray(node) && node.length) || node,
         'Provided slot "rejected" is empty. Cannot display the error'


### PR DESCRIPTION
I'd like to introduce a rejected slot but without scoped data

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
