### PR TITLE
Export Promised value to Typescript (fixes #21)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,12 +20,10 @@ interface Props {
   pendingDelay: Number | String
 }
 
-export type Promised = ComponentOptions<
+export var Promised: ComponentOptions<
   never,
   Data,
   DefaultMethods<never>,
   DefaultComputed,
   Props
 >
-
-export var Promised: Promised;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,3 +27,5 @@ export type Promised = ComponentOptions<
   DefaultComputed,
   Props
 >
+
+export var Promised: Promised;


### PR DESCRIPTION
Added a declaration of the global Promised value for typescript code.
Without this, Javascript will work but the Typescript compiler will fail
with `'Promised' only refers to a type, but is being used as a value
here.` breaking the build.

(I'd like to add that I'm no Typescript expert - this is what I and 2 of my colleagues came up with to make the code work both in JS & TS)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included