### PR TITLE
Fix #35 - Typescript compatibility with newer Vue 

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,9 @@ import {
   DefaultMethods,
   DefaultComputed,
   ComponentOptions,
+  PropsDefinition,
 } from 'vue/types/options'
+import { Vue } from 'vue/types/vue';
 
 interface Data {
   (): {
@@ -21,9 +23,9 @@ interface Props {
 }
 
 export var Promised: ComponentOptions<
-  never,
+  Vue,
   Data,
-  DefaultMethods<never>,
+  DefaultMethods<Vue>,
   DefaultComputed,
-  Props
+  PropsDefinition<Props>
 >

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,8 +1,12 @@
 import Vue from 'vue'
 import { Promised } from '../'
 
-const P = {} as Promised
+Vue.component('Promised', Promised);
 
 new Vue({
-  components: { P },
+  components: { Promised },
+})
+
+Vue.extend({
+  extends: Promised
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

I'm not sure - it seems like maybe this used to work with older versions of Vue? I can confirm that this fixes on latest 2.6 version of Vue.

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

**Other information:**
