### PR TITLE
feat: reset Promised state to initial when promise is set to null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,9 +91,15 @@ export const Promised = {
   watch: {
     promise: {
       handler (promise) {
-        if (!promise) return
         this.resolved = false
         this.error = null
+        if (!promise) {
+          this.data = null
+          this.isDelayElapsed = false
+          if (this.timerId) clearTimeout(this.timerId)
+          this.timerId = null
+          return
+        }
         this.setupDelay()
         promise
           .then(data => {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -129,6 +129,14 @@ describe('Promised', () => {
         })
         expect(clearTimeout).toHaveBeenCalled()
       })
+
+      it('cancels timeout when promise is set to null', () => {
+        expect(setTimeout).toHaveBeenCalledTimes(1)
+        wrapper.setProps({
+          promise: null,
+        })
+        expect(clearTimeout).toHaveBeenCalledTimes(1)
+      })
     })
 
     describe('multipe children', () => {
@@ -329,6 +337,19 @@ describe('Promised', () => {
       expect(wrapper.find('.pending').text()).toBe('false')
       expect(wrapper.find('.delay').text()).toBe('true')
       expect(wrapper.find('.data').text()).toBe('bar')
+    })
+
+    it('data is reset when promise is set to null', async () => {
+      resolve('foo')
+      await tick()
+      expect(wrapper.find('.pending').text()).toBe('false')
+      expect(wrapper.find('.delay').text()).toBe('true')
+      expect(wrapper.find('.data').text()).toBe('foo')
+
+      wrapper.setProps({ promise: null })
+      await tick()
+
+      expect(wrapper.text()).toBe('true false')
     })
 
     it('throws if slot is empty', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

Some existing code might rely on the fact that the state is kept when the promise prop is set to `null`. This is probably not a common usage pattern though. Even when reusing the component as loading indicator one would normally just set the new promise without intermediate reset to `null`.

Furthermore the previous behavior was not compatible with the described behavior in the readme documentation.

**The PR fulfills these requirements:**

- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [X] New/updated tests are included